### PR TITLE
Add child window management when closing main app or logging out

### DIFF
--- a/components/main-app/hooks/useWindowManagement.ts
+++ b/components/main-app/hooks/useWindowManagement.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { requestCloseAllChildWindows } from "@/lib/window";
 
 interface UseWindowManagementProps {
   dbPath: string;
@@ -45,8 +46,14 @@ export function useWindowManagement({ dbPath, isDirty, onCloseRequested }: UseWi
           // Close to tray enabled and no unsaved changes
           event.preventDefault();
           await appWindow.hide();
+        } else {
+          // Main window is closing - request all child windows to close first
+          const allClosed = await requestCloseAllChildWindows();
+          if (!allClosed) {
+            // Some windows stayed open (user cancelled due to unsaved changes)
+            event.preventDefault();
+          }
         }
-        // Otherwise let window close normally
       });
     };
 

--- a/components/main-app/index.tsx
+++ b/components/main-app/index.tsx
@@ -6,7 +6,7 @@ import { GroupTree } from "@/components/group-tree";
 import { EntryList } from "@/components/entry-list";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { Dashboard } from "@/components/Dashboard";
-import { openEntryWindow } from "@/lib/window";
+import { openEntryWindow, requestCloseAllChildWindows } from "@/lib/window";
 import { useToast } from "@/components/ui/use-toast";
 import type { GroupData, EntryData } from "@/lib/tauri";
 import { loadGroupTreeState } from "@/lib/group-state";
@@ -52,6 +52,15 @@ export function MainApp({ onClose }: MainAppProps) {
   // Define performClose
   const performClose = useCallback(async (isManualLogout: boolean = false) => {
     try {
+      // Request all child windows to close (they will prompt for unsaved changes)
+      const allClosed = await requestCloseAllChildWindows();
+      
+      if (!allClosed) {
+        // Some windows stayed open (user cancelled due to unsaved changes)
+        // Abort the logout/close
+        return;
+      }
+      
       const appWindow = getCurrentWindow();
       await appWindow.setTitle("Simple Password Manager");
       

--- a/lib/window.ts
+++ b/lib/window.ts
@@ -1,5 +1,87 @@
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { WebviewWindow, getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import type { EntryData } from "@/lib/tauri";
+
+// Labels for child windows that should be closed when main app closes/logs out
+const CHILD_WINDOW_PREFIXES = ['entry-', 'settings'];
+
+/**
+ * Check if there are any open child windows (entry editors, settings)
+ */
+export async function hasOpenChildWindows(): Promise<boolean> {
+  try {
+    const allWindows = await getAllWebviewWindows();
+    return allWindows.some(win => 
+      CHILD_WINDOW_PREFIXES.some(prefix => win.label.startsWith(prefix))
+    );
+  } catch (error) {
+    console.error("Failed to check child windows:", error);
+    return false;
+  }
+}
+
+/**
+ * Request all child windows to close. Uses close() instead of destroy()
+ * so that windows with unsaved changes can prompt the user first.
+ * Returns true if all windows were closed, false if any remained open.
+ */
+export async function requestCloseAllChildWindows(): Promise<boolean> {
+  try {
+    const allWindows = await getAllWebviewWindows();
+    
+    const childWindows = allWindows.filter(win => 
+      CHILD_WINDOW_PREFIXES.some(prefix => win.label.startsWith(prefix))
+    );
+    
+    if (childWindows.length === 0) {
+      return true;
+    }
+    
+    // Request each window to close (triggers onCloseRequested which handles unsaved changes)
+    for (const win of childWindows) {
+      try {
+        await win.close();
+        console.log(`Requested close for child window: ${win.label}`);
+      } catch (error) {
+        console.error(`Failed to request close for window ${win.label}:`, error);
+      }
+    }
+    
+    // Wait a moment for windows to process close requests and dialogs
+    await new Promise(resolve => setTimeout(resolve, 100));
+    
+    // Check if all child windows are actually closed
+    const stillOpen = await hasOpenChildWindows();
+    return !stillOpen;
+  } catch (error) {
+    console.error("Failed to close child windows:", error);
+    return false;
+  }
+}
+
+/**
+ * Force close all child windows without prompting (use destroy)
+ */
+export async function forceCloseAllChildWindows(): Promise<void> {
+  try {
+    const allWindows = await getAllWebviewWindows();
+    
+    for (const win of allWindows) {
+      const label = win.label;
+      const isChildWindow = CHILD_WINDOW_PREFIXES.some(prefix => label.startsWith(prefix));
+      
+      if (isChildWindow) {
+        try {
+          await win.destroy();
+          console.log(`Force closed child window: ${label}`);
+        } catch (error) {
+          console.error(`Failed to force close window ${label}:`, error);
+        }
+      }
+    }
+  } catch (error) {
+    console.error("Failed to force close child windows:", error);
+  }
+}
 
 export async function openEntryWindow(entry: EntryData, groupUuid: string) {
   try {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,8 @@
             "core:window:allow-hide",
             "core:window:allow-show",
             "core:webview:allow-create-webview-window",
+            "core:webview:allow-webview-close",
+            "core:webview:allow-get-all-webviews",
             "core:event:allow-listen",
             "core:event:allow-emit",
             "dialog:allow-open",


### PR DESCRIPTION
### **User description**
This pull request introduces robust management of child windows (such as entry editors and settings) in the main application. Now, when the main window is closed or the user logs out, the application will request all relevant child windows to close first, ensuring that users are prompted to save unsaved changes before quitting. The implementation includes utility functions for detecting and closing child windows, and updates the main app logic to use these utilities. Additionally, the Tauri configuration is updated to allow the necessary window operations.

**Child window management utilities:**

* Added `requestCloseAllChildWindows`, `hasOpenChildWindows`, and `forceCloseAllChildWindows` utility functions to `lib/window.ts` for managing child windows, including logic to prompt for unsaved changes and force-close when necessary.
* Updated Tauri configuration (`src-tauri/tauri.conf.json`) to permit closing and querying all webview windows, enabling the new window management features.

**Main window and logout logic:**

* Updated `useWindowManagement` hook to request all child windows to close before allowing the main window to close, preventing accidental data loss. [[1]](diffhunk://#diff-6d1a08c03383384ec64cedab2af743488fea5b9b5fbb2c42a1b6f1278c8500c3R5) [[2]](diffhunk://#diff-6d1a08c03383384ec64cedab2af743488fea5b9b5fbb2c42a1b6f1278c8500c3R49-L49)
* Modified the main app's `performClose` function to abort logout if any child window remains open (e.g., due to unsaved changes), using the new utility.
* Ensured all relevant imports for the new utilities are included in the main app component.…logging out

- Add requestCloseAllChildWindows, hasOpenChildWindows, and forceCloseAllChildWindows functions to window.ts
- Request all child windows (entry editors, settings) to close before main window closes or logout
- Use close() instead of destroy() to allow unsaved changes prompts in child windows
- Abort logout/close if user cancels unsaved changes in any child window
- Add required Tauri permissions for webview-close and get


___

### **PR Type**
Enhancement


___

### **Description**
- Add child window management utilities for graceful closure handling

- Request child windows to close before main app closes or logout

- Prompt users to save unsaved changes in child windows before closing

- Abort logout if user cancels unsaved changes in any child window

- Add required Tauri permissions for webview operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MainClose["Main Window Close Event"]
  ReqClose["requestCloseAllChildWindows"]
  CheckOpen["Check if windows still open"]
  AllClosed{"All closed?"}
  Proceed["Allow main close/logout"]
  Abort["Abort close/logout"]
  
  MainClose --> ReqClose
  ReqClose --> CheckOpen
  CheckOpen --> AllClosed
  AllClosed -->|Yes| Proceed
  AllClosed -->|No| Abort
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>window.ts</strong><dd><code>Add child window management utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/window.ts

<ul><li>Added <code>hasOpenChildWindows()</code> function to detect open child windows by <br>label prefix<br> <li> Added <code>requestCloseAllChildWindows()</code> function using <code>close()</code> to allow <br>unsaved changes prompts<br> <li> Added <code>forceCloseAllChildWindows()</code> function using <code>destroy()</code> for forced <br>closure<br> <li> Imported <code>getAllWebviewWindows</code> from Tauri API for window enumeration</ul>


</details>


  </td>
  <td><a href="https://github.com/jonax1337/Password-Manager/pull/18/files#diff-ddd59270efedf56091843c26e872b3ba955606a75ab84e1e1f56b62ffda10399">+83/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useWindowManagement.ts</strong><dd><code>Request child windows close before main window</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/main-app/hooks/useWindowManagement.ts

<ul><li>Imported <code>requestCloseAllChildWindows</code> utility function<br> <li> Added logic to request child windows close before main window closes<br> <li> Prevent main window close if any child window remains open due to <br>unsaved changes<br> <li> Removed fallthrough behavior allowing normal window close</ul>


</details>


  </td>
  <td><a href="https://github.com/jonax1337/Password-Manager/pull/18/files#diff-6d1a08c03383384ec64cedab2af743488fea5b9b5fbb2c42a1b6f1278c8500c3">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Check child windows before logout in main app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/main-app/index.tsx

<ul><li>Imported <code>requestCloseAllChildWindows</code> function from window utilities<br> <li> Added child window closure check in <code>performClose</code> callback<br> <li> Abort logout/close operation if any child window remains open<br> <li> Ensures unsaved changes are handled before logout</ul>


</details>


  </td>
  <td><a href="https://github.com/jonax1337/Password-Manager/pull/18/files#diff-1d575f26c615a1b08eeddff4410534e1a848bb162cb58f0514b0fdd6ba877586">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Add Tauri permissions for webview operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/tauri.conf.json

<ul><li>Added <code>core:webview:allow-webview-close</code> permission for closing child <br>windows<br> <li> Added <code>core:webview:allow-get-all-webviews</code> permission for querying all <br>webview windows<br> <li> Enables Tauri API calls for window management operations</ul>


</details>


  </td>
  <td><a href="https://github.com/jonax1337/Password-Manager/pull/18/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

