### PR TITLE
Feature - Custom title bar

### DIFF
--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Minus, Square, X, Copy, Save, Settings, LogOut, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -122,7 +123,7 @@ export function CustomTitleBar({
           )}
           <button
             onClick={handleClose}
-            className="h-full pl-4 pr-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
+            className="h-full px-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
             aria-label="Close"
           >
             <X className="h-4 w-4" />
@@ -135,7 +136,7 @@ export function CustomTitleBar({
   // Menu bar mode (for main app - minimal with File menu and DB name)
   return (
     <div 
-      className="h-9 bg-muted/50 border-b select-none flex items-center justify-between px-2 relative"
+      className="h-9 bg-muted/50 border-b select-none flex items-center justify-between pl-2 relative"
       data-tauri-drag-region
       onMouseDown={(e) => {
         if (e.target === e.currentTarget || (e.target as HTMLElement).hasAttribute('data-tauri-drag-region')) {
@@ -186,24 +187,30 @@ export function CustomTitleBar({
       </div>
 
       {/* Right: Search + Settings + Window Controls */}
-      <div className="flex items-center h-full z-10">
+      <div className="flex items-center gap-1 h-full z-10">
         {onToggleSearch && (
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
             onClick={onToggleSearch}
-            className="h-full px-3 hover:bg-accent transition-colors flex items-center justify-center"
             title="Toggle Search (Ctrl+F)"
           >
-            <Search className="h-3.5 w-3.5" />
-          </button>
+            <Search className="h-4 w-4" />
+          </Button>
         )}
         
-        <button
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
           onClick={() => openSettingsWindow()}
-          className="h-full px-3 hover:bg-accent transition-colors flex items-center justify-center"
           title="Settings"
         >
-          <Settings className="h-3.5 w-3.5" />
-        </button>
+          <Settings className="h-4 w-4" />
+        </Button>
+
+        <div className="h-5 w-px bg-border mx-1" />
 
         <button
           onClick={handleMinimize}
@@ -227,7 +234,7 @@ export function CustomTitleBar({
         )}
         <button
           onClick={handleClose}
-          className="h-full pl-3 pr-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
+          className="h-full px-3 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
           aria-label="Close"
         >
           <X className="h-4 w-4" />

--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { Minus, Square, X, Copy } from "lucide-react";
+
+interface CustomTitleBarProps {
+  title?: string;
+  hideMaximize?: boolean;
+}
+
+export function CustomTitleBar({ title = "Simple Password Manager", hideMaximize = false }: CustomTitleBarProps) {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    const checkMaximized = async () => {
+      const appWindow = getCurrentWindow();
+      const maximized = await appWindow.isMaximized();
+      setIsMaximized(maximized);
+    };
+
+    checkMaximized();
+
+    const unlisten = getCurrentWindow().onResized(() => {
+      checkMaximized();
+    });
+
+    return () => {
+      unlisten.then(fn => fn());
+    };
+  }, []);
+
+  const handleMinimize = async () => {
+    const appWindow = getCurrentWindow();
+    await appWindow.minimize();
+  };
+
+  const handleMaximize = async () => {
+    const appWindow = getCurrentWindow();
+    if (isMaximized) {
+      await appWindow.unmaximize();
+    } else {
+      await appWindow.maximize();
+    }
+    setIsMaximized(!isMaximized);
+  };
+
+  const handleClose = async () => {
+    const appWindow = getCurrentWindow();
+    await appWindow.close();
+  };
+
+  const startDragging = async () => {
+    const appWindow = getCurrentWindow();
+    await appWindow.startDragging();
+  };
+
+  return (
+    <div 
+      className="h-9 bg-muted/50 border-b flex items-center justify-between select-none"
+      data-tauri-drag-region
+      onMouseDown={(e) => {
+        // Only start dragging if clicking on the title bar itself, not on buttons
+        if (e.target === e.currentTarget || (e.target as HTMLElement).hasAttribute('data-tauri-drag-region')) {
+          startDragging();
+        }
+      }}
+    >
+      <div className="flex items-center px-4 flex-1" data-tauri-drag-region>
+        <img 
+          src="/app-icon.png" 
+          alt="App Icon" 
+          className="h-4 w-4 mr-2 pointer-events-none"
+        />
+        <span className="text-sm font-medium text-foreground pointer-events-none">
+          {title}
+        </span>
+      </div>
+
+      <div className="flex items-center h-full">
+        <button
+          onClick={handleMinimize}
+          className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
+          aria-label="Minimize"
+        >
+          <Minus className="h-3.5 w-3.5" />
+        </button>
+        {!hideMaximize && (
+          <button
+            onClick={handleMaximize}
+            className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
+            aria-label={isMaximized ? "Restore" : "Maximize"}
+          >
+            {isMaximized ? (
+              <Copy className="h-3 w-3" />
+            ) : (
+              <Square className="h-3 w-3" />
+            )}
+          </button>
+        )}
+        <button
+          onClick={handleClose}
+          className="h-full px-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -77,63 +77,7 @@ export function CustomTitleBar({
     await appWindow.startDragging();
   };
 
-  // Simple title bar (for Settings, Entry, Unlock screens)
-  if (!showMenu) {
-    return (
-      <div 
-        className="h-9 bg-muted/50 border-b flex items-center justify-between select-none"
-        data-tauri-drag-region
-        onMouseDown={(e) => {
-          if (e.target === e.currentTarget || (e.target as HTMLElement).hasAttribute('data-tauri-drag-region')) {
-            startDragging();
-          }
-        }}
-      >
-        <div className="flex items-center px-4 flex-1" data-tauri-drag-region>
-          <img 
-            src="/app-icon.png" 
-            alt="App Icon" 
-            className="h-4 w-4 mr-2 pointer-events-none"
-          />
-          <span className="text-xs font-medium text-foreground pointer-events-none">
-            {title}
-          </span>
-        </div>
-
-        <div className="flex items-center h-full">
-          <button
-            onClick={handleMinimize}
-            className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
-            aria-label="Minimize"
-          >
-            <Minus className="h-3.5 w-3.5" />
-          </button>
-          {!hideMaximize && (
-            <button
-              onClick={handleMaximize}
-              className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
-              aria-label={isMaximized ? "Restore" : "Maximize"}
-            >
-              {isMaximized ? (
-                <Copy className="h-3 w-3" />
-              ) : (
-                <Square className="h-3 w-3" />
-              )}
-            </button>
-          )}
-          <button
-            onClick={handleClose}
-            className="h-full px-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
-            aria-label="Close"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // Menu bar mode (for main app - minimal with File menu and DB name)
+  // Unified title bar layout: Icon left --- Title centered --- Window Controls right
   return (
     <div 
       className="h-9 bg-muted/50 border-b select-none flex items-center justify-between pl-2 relative"
@@ -144,51 +88,53 @@ export function CustomTitleBar({
         }
       }}
     >
-      {/* Left: Icon + File Menu */}
+      {/* Left: Icon + Optional File Menu (only for main app) */}
       <div className="flex items-center gap-2 z-10">
         <img 
           src="/app-icon.png" 
           alt="App Icon" 
           className="h-4 w-4"
         />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="px-2 py-1 text-xs font-medium hover:bg-accent rounded transition-colors">
-              File
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-48">
-            <DropdownMenuItem
-              onClick={onSave}
-              disabled={!isDirty}
-              className="gap-2 cursor-pointer"
-            >
-              <Save className="h-4 w-4" />
-              <span>Save Database</span>
-              <span className="ml-auto text-xs text-muted-foreground">Ctrl+S</span>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={onLogout}
-              className="gap-2 cursor-pointer"
-            >
-              <LogOut className="h-4 w-4" />
-              <span>Logout</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {showMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="px-2 py-1 text-xs font-medium hover:bg-accent rounded transition-colors">
+                File
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-48">
+              <DropdownMenuItem
+                onClick={onSave}
+                disabled={!isDirty}
+                className="gap-2 cursor-pointer"
+              >
+                <Save className="h-4 w-4" />
+                <span>Save Database</span>
+                <span className="ml-auto text-xs text-muted-foreground">Ctrl+S</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={onLogout}
+                className="gap-2 cursor-pointer"
+              >
+                <LogOut className="h-4 w-4" />
+                <span>Logout</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
 
-      {/* Center: DB Name */}
+      {/* Center: Title */}
       <div className="absolute left-1/2 -translate-x-1/2 flex items-center" data-tauri-drag-region>
         <span className="text-xs font-semibold text-foreground truncate max-w-md">
           {title}
         </span>
       </div>
 
-      {/* Right: Search + Settings + Window Controls */}
+      {/* Right: Optional Search + Settings + Window Controls */}
       <div className="flex items-center gap-1 h-full z-10">
-        {onToggleSearch && (
+        {showMenu && onToggleSearch && (
           <Button
             variant="ghost"
             size="icon"
@@ -200,17 +146,19 @@ export function CustomTitleBar({
           </Button>
         )}
         
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={() => openSettingsWindow()}
-          title="Settings"
-        >
-          <Settings className="h-4 w-4" />
-        </Button>
+        {showMenu && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => openSettingsWindow()}
+            title="Settings"
+          >
+            <Settings className="h-4 w-4" />
+          </Button>
+        )}
 
-        <div className="h-5 w-px bg-border mx-1" />
+        {showMenu && <div className="h-5 w-px bg-border mx-1" />}
 
         <button
           onClick={handleMinimize}

--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -1,16 +1,52 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Minus, Square, X, Copy } from "lucide-react";
+import { Minus, Square, X, Copy, Search, Save, Settings, LogOut, Globe, Folder, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { openSettingsWindow } from "@/lib/window";
+import type { SearchScope } from "@/lib/storage";
 
 interface CustomTitleBarProps {
   title?: string;
   hideMaximize?: boolean;
+  // Menu mode props (for main app)
+  showMenu?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  isDirty?: boolean;
+  onSave?: () => void;
+  onLogout?: () => void;
+  searchScope?: SearchScope;
+  onSearchScopeChange?: (scope: SearchScope) => void;
+  showSearchScopeDropdown?: boolean;
+  isSearchScopeDisabled?: boolean;
 }
 
-export function CustomTitleBar({ title = "Simple Password Manager", hideMaximize = false }: CustomTitleBarProps) {
+export function CustomTitleBar({ 
+  title = "Simple Password Manager", 
+  hideMaximize = false,
+  showMenu = false,
+  searchQuery = "",
+  onSearchChange,
+  isDirty = false,
+  onSave,
+  onLogout,
+  searchScope = "global",
+  onSearchScopeChange,
+  showSearchScopeDropdown = false,
+  isSearchScopeDisabled = false,
+}: CustomTitleBarProps) {
   const [isMaximized, setIsMaximized] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const checkMaximized = async () => {
@@ -29,6 +65,26 @@ export function CustomTitleBar({ title = "Simple Password Manager", hideMaximize
       unlisten.then(fn => fn());
     };
   }, []);
+
+  // Keyboard shortcut: Ctrl+F / Cmd+F to focus search bar
+  useEffect(() => {
+    if (!showMenu) return; // Only for menu mode
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Ctrl+F (Windows/Linux) or Cmd+F (Mac)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [showMenu]);
 
   const handleMinimize = async () => {
     const appWindow = getCurrentWindow();
@@ -55,29 +111,178 @@ export function CustomTitleBar({ title = "Simple Password Manager", hideMaximize
     await appWindow.startDragging();
   };
 
+  // Simple title bar (for Settings, Entry, Unlock screens)
+  if (!showMenu) {
+    return (
+      <div 
+        className="h-9 bg-muted/50 border-b flex items-center justify-between select-none"
+        data-tauri-drag-region
+        onMouseDown={(e) => {
+          if (e.target === e.currentTarget || (e.target as HTMLElement).hasAttribute('data-tauri-drag-region')) {
+            startDragging();
+          }
+        }}
+      >
+        <div className="flex items-center px-4 flex-1" data-tauri-drag-region>
+          <img 
+            src="/app-icon.png" 
+            alt="App Icon" 
+            className="h-4 w-4 mr-2 pointer-events-none"
+          />
+          <span className="text-xs font-medium text-foreground pointer-events-none">
+            {title}
+          </span>
+        </div>
+
+        <div className="flex items-center h-full">
+          <button
+            onClick={handleMinimize}
+            className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
+            aria-label="Minimize"
+          >
+            <Minus className="h-3.5 w-3.5" />
+          </button>
+          {!hideMaximize && (
+            <button
+              onClick={handleMaximize}
+              className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"
+              aria-label={isMaximized ? "Restore" : "Maximize"}
+            >
+              {isMaximized ? (
+                <Copy className="h-3 w-3" />
+              ) : (
+                <Square className="h-3 w-3" />
+              )}
+            </button>
+          )}
+          <button
+            onClick={handleClose}
+            className="h-full px-4 hover:bg-destructive hover:text-destructive-foreground transition-colors flex items-center justify-center"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Menu bar mode (for main app - VS Code style)
   return (
     <div 
-      className="h-9 bg-muted/50 border-b flex items-center justify-between select-none"
+      className="h-9 bg-muted/50 border-b flex items-center justify-between select-none relative"
       data-tauri-drag-region
       onMouseDown={(e) => {
-        // Only start dragging if clicking on the title bar itself, not on buttons
         if (e.target === e.currentTarget || (e.target as HTMLElement).hasAttribute('data-tauri-drag-region')) {
           startDragging();
         }
       }}
     >
-      <div className="flex items-center px-4 flex-1" data-tauri-drag-region>
+      {/* Left: Icon + File Menu */}
+      <div className="flex items-center gap-1 px-2 z-10">
         <img 
           src="/app-icon.png" 
           alt="App Icon" 
-          className="h-4 w-4 mr-2 pointer-events-none"
+          className="h-4 w-4 mr-1"
         />
-        <span className="text-xs font-medium text-foreground pointer-events-none">
-          {title}
-        </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="px-2 py-1 text-xs font-medium hover:bg-accent rounded transition-colors">
+              File
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-48">
+            <DropdownMenuItem
+              onClick={onSave}
+              disabled={!isDirty}
+              className="gap-2 cursor-pointer"
+            >
+              <Save className="h-4 w-4" />
+              <span>Save Database</span>
+              <span className="ml-auto text-xs text-muted-foreground">Ctrl+S</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onLogout}
+              className="gap-2 cursor-pointer"
+            >
+              <LogOut className="h-4 w-4" />
+              <span>Logout</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
-      <div className="flex items-center h-full">
+      {/* Center: Search Bar - Absolutely positioned for perfect centering */}
+      <div className="absolute left-1/2 -translate-x-1/2 w-full max-w-xs px-2 sm:max-w-md sm:px-8 md:max-w-lg md:px-12 lg:max-w-xl lg:px-16 xl:max-w-2xl xl:px-20" data-tauri-drag-region>
+        <div className="relative w-full">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            ref={searchInputRef}
+            placeholder="Search entries..."
+            className={`h-7 text-xs pl-8 ${showSearchScopeDropdown ? 'pr-28' : 'pr-2'}`}
+            value={searchQuery}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+          />
+          {showSearchScopeDropdown && (
+            <div className="absolute right-1.5 top-1/2 -translate-y-1/2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild disabled={isSearchScopeDisabled}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={`h-6 gap-1 px-2 text-xs flex items-center ${isSearchScopeDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    disabled={isSearchScopeDisabled}
+                  >
+                    {searchScope === "global" ? (
+                      <>
+                        <Globe className="h-3 w-3" />
+                        <span className="text-[10px]">Global</span>
+                      </>
+                    ) : (
+                      <>
+                        <Folder className="h-3 w-3" />
+                        <span className="text-[10px]">Folder</span>
+                      </>
+                    )}
+                    <ChevronDown className="h-2.5 w-2.5 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-36">
+                  <DropdownMenuItem
+                    onClick={() => onSearchScopeChange?.("global")}
+                    className="gap-2 cursor-pointer text-xs"
+                  >
+                    <Globe className="h-3.5 w-3.5" />
+                    <span>Global</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => onSearchScopeChange?.("folder")}
+                    className="gap-2 cursor-pointer text-xs"
+                  >
+                    <Folder className="h-3.5 w-3.5" />
+                    <span>Folder</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Right: Action Buttons + Window Controls */}
+      <div className="flex items-center h-full z-10">
+        
+        {/* Settings Button */}
+        <button
+          onClick={() => openSettingsWindow()}
+          className="h-full px-3 hover:bg-accent transition-colors flex items-center justify-center"
+          title="Settings"
+        >
+          <Settings className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Window Controls */}
         <button
           onClick={handleMinimize}
           className="h-full px-4 hover:bg-accent transition-colors flex items-center justify-center"

--- a/components/CustomTitleBar.tsx
+++ b/components/CustomTitleBar.tsx
@@ -72,7 +72,7 @@ export function CustomTitleBar({ title = "Simple Password Manager", hideMaximize
           alt="App Icon" 
           className="h-4 w-4 mr-2 pointer-events-none"
         />
-        <span className="text-sm font-medium text-foreground pointer-events-none">
+        <span className="text-xs font-medium text-foreground pointer-events-none">
           {title}
         </span>
       </div>

--- a/components/QuickUnlockScreen.tsx
+++ b/components/QuickUnlockScreen.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { openDatabase } from "@/lib/tauri";
 import { useToast } from "@/components/ui/use-toast";
 import { KdfWarningDialog } from "@/components/KdfWarningDialog";
+import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { invoke } from "@tauri-apps/api/core";
 
 interface QuickUnlockScreenProps {
@@ -118,7 +119,9 @@ export function QuickUnlockScreen({
         databasePath={lastDatabasePath}
       />
       
-      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
+      <div className="flex h-full w-full flex-col">
+        <CustomTitleBar />
+        <div className="flex flex-1 items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
       <div className="w-full max-w-sm space-y-6 rounded-lg border bg-card p-6 shadow-lg">
         <div className="flex flex-col items-center space-y-2">
           <Image
@@ -165,6 +168,7 @@ export function QuickUnlockScreen({
             Open Different Database
           </Button>
         </div>
+      </div>
       </div>
     </div>
     </>

--- a/components/SearchHeader.tsx
+++ b/components/SearchHeader.tsx
@@ -51,19 +51,6 @@ export function SearchHeader({
       }`}
     >
       <div className="max-w-4xl mx-auto relative">
-        {onToggle && (
-          <button
-            onClick={onToggle}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded transition-colors"
-            title={isVisible ? "Hide search" : "Show search"}
-          >
-            {isVisible ? (
-              <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-            )}
-          </button>
-        )}
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input

--- a/components/SearchHeader.tsx
+++ b/components/SearchHeader.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Search, Globe, Folder, ChevronDown, ChevronUp } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useRef, useEffect } from "react";
+
+interface SearchHeaderProps {
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  searchScope?: "global" | "folder";
+  onSearchScopeChange?: (scope: "global" | "folder") => void;
+  showSearchScopeDropdown?: boolean;
+  isSearchScopeDisabled?: boolean;
+  isVisible?: boolean;
+  onToggle?: () => void;
+}
+
+export function SearchHeader({
+  searchQuery = "",
+  onSearchChange,
+  searchScope = "global",
+  onSearchScopeChange,
+  showSearchScopeDropdown = false,
+  isSearchScopeDisabled = false,
+  isVisible = true,
+  onToggle,
+}: SearchHeaderProps) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus search bar when visible
+  useEffect(() => {
+    if (isVisible) {
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }, 100);
+    }
+  }, [isVisible]);
+
+  return (
+    <div 
+      className={`bg-background/95 backdrop-blur-sm border-b px-6 transition-all duration-300 ease-in-out overflow-hidden ${
+        isVisible ? 'py-3 max-h-24' : 'py-0 max-h-0 border-b-0'
+      }`}
+    >
+      <div className="max-w-4xl mx-auto relative">
+        {onToggle && (
+          <button
+            onClick={onToggle}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded transition-colors"
+            title={isVisible ? "Hide search" : "Show search"}
+          >
+            {isVisible ? (
+              <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+          </button>
+        )}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            ref={searchInputRef}
+            placeholder="Search entries..."
+            className={`h-10 pl-10 text-sm ${showSearchScopeDropdown ? 'pr-32' : 'pr-4'} border-2 focus-visible:ring-2 focus-visible:ring-offset-0`}
+            value={searchQuery}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+          />
+          {showSearchScopeDropdown && (
+            <div className="absolute right-2 top-1/2 -translate-y-1/2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild disabled={isSearchScopeDisabled}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={`h-7 gap-2 px-3 text-xs font-medium ${isSearchScopeDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    disabled={isSearchScopeDisabled}
+                  >
+                    {searchScope === "global" ? (
+                      <>
+                        <Globe className="h-3.5 w-3.5" />
+                        <span>Global</span>
+                      </>
+                    ) : (
+                      <>
+                        <Folder className="h-3.5 w-3.5" />
+                        <span>Folder</span>
+                      </>
+                    )}
+                    <ChevronDown className="h-3 w-3 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  <DropdownMenuItem
+                    onClick={() => onSearchScopeChange?.("global")}
+                    className="gap-2 cursor-pointer"
+                  >
+                    <Globe className="h-4 w-4" />
+                    <span>Global</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => onSearchScopeChange?.("folder")}
+                    className="gap-2 cursor-pointer"
+                  >
+                    <Folder className="h-4 w-4" />
+                    <span>Folder</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -328,13 +328,6 @@ export function Settings() {
           </ScrollArea>
         </TabsContent>
       </Tabs>
-
-      {/* Footer */}
-      <div className="flex-shrink-0 flex items-center justify-end gap-2 border-t px-4 py-3 bg-background">
-        <Button variant="outline" onClick={handleClose}>
-          Close
-        </Button>
-      </div>
     </div>
   );
 }

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { getHibpEnabled, setHibpEnabled, getLiveUpdates, setLiveUpdates } from "@/lib/storage";
 
 export function Settings() {
@@ -101,6 +102,7 @@ export function Settings() {
 
   return (
     <div className="flex h-screen flex-col bg-background">
+      <CustomTitleBar title="Settings" hideMaximize />
       {/* Header */}
       <div className="flex-shrink-0 flex items-center gap-3 border-b px-4 py-3 bg-muted/30">
         <div className="h-10 w-10 flex items-center justify-center rounded-md bg-primary/10">

--- a/components/UnlockScreen.tsx
+++ b/components/UnlockScreen.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { open } from "@tauri-apps/plugin-dialog";
 import { CreateDatabaseDialog } from "@/components/CreateDatabaseDialog";
 import { KdfWarningDialog } from "@/components/KdfWarningDialog";
+import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { saveLastDatabasePath } from "@/lib/storage";
 import { invoke } from "@tauri-apps/api/core";
 import Image from "next/image";
@@ -157,7 +158,9 @@ export function UnlockScreen({ onUnlock, initialFilePath }: UnlockScreenProps) {
         databasePath={filePath}
       />
       
-      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
+      <div className="flex h-full w-full flex-col">
+        <CustomTitleBar />
+        <div className="flex flex-1 items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
         <div className="w-full max-w-md space-y-8 rounded-lg border bg-card p-8 shadow-lg">
           <div className="flex flex-col items-center space-y-4">
             <Image 
@@ -235,6 +238,7 @@ export function UnlockScreen({ onUnlock, initialFilePath }: UnlockScreenProps) {
               Create New Database
             </Button>
           </div>
+        </div>
         </div>
       </div>
     </>

--- a/components/entry-editor/index.tsx
+++ b/components/entry-editor/index.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { emit } from "@tauri-apps/api/event";
 import { IconPicker } from "@/components/IconPicker";
+import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { GeneralTab } from "./GeneralTab";
 import { AdvancedTab } from "./AdvancedTab";
 import { HistoryTab } from "./HistoryTab";
@@ -203,6 +204,7 @@ export function EntryEditor({ entry, onClose, onRefresh, onHasChangesChange }: E
 
   return (
     <div className="flex h-full flex-col">
+      <CustomTitleBar title={`Edit Entry - ${formData.title}`} hideMaximize />
       {/* Header */}
       <div className="flex-shrink-0 flex items-center gap-3 border-b px-4 py-3 bg-muted/30">
         <IconPicker value={iconId} onChange={handleIconChange} />

--- a/components/main-app/hooks/useKeyboardShortcuts.ts
+++ b/components/main-app/hooks/useKeyboardShortcuts.ts
@@ -4,18 +4,32 @@ import { useEffect } from "react";
 
 interface UseKeyboardShortcutsProps {
   onSave: () => void;
+  onToggleSearch?: () => void;
+  onCloseSearch?: () => void;
+  isSearchVisible?: boolean;
 }
 
-export function useKeyboardShortcuts({ onSave }: UseKeyboardShortcutsProps) {
+export function useKeyboardShortcuts({ onSave, onToggleSearch, onCloseSearch, isSearchVisible }: UseKeyboardShortcutsProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Ctrl/Cmd+S: Save
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         onSave();
+      }
+      // Ctrl/Cmd+F: Open search
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        onToggleSearch?.();
+      }
+      // ESC: Close search if visible
+      if (e.key === 'Escape' && isSearchVisible) {
+        e.preventDefault();
+        onCloseSearch?.();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onSave]);
+  }, [onSave, onToggleSearch, onCloseSearch, isSearchVisible]);
 }

--- a/components/main-app/hooks/useWindowManagement.ts
+++ b/components/main-app/hooks/useWindowManagement.ts
@@ -18,19 +18,20 @@ export function useWindowManagement({ dbPath, isDirty, onCloseRequested }: UseWi
     isDirtyRef.current = isDirty;
   }, [isDirty]);
 
-  // Update window title with database path and unsaved indicator
+  // Compute window title
+  const fileName = dbPath ? dbPath.split(/[\\/]/).pop() || dbPath : '';
+  const windowTitle = fileName
+    ? (isDirty ? `${fileName}* - Simple Password Manager` : `${fileName} - Simple Password Manager`)
+    : 'Simple Password Manager';
+
+  // Update window title (still needed for native title in case decorations are enabled)
   useEffect(() => {
     const updateTitle = async () => {
       const appWindow = getCurrentWindow();
-      // Extract filename from full path
-      const fileName = dbPath ? dbPath.split(/[\\/]/).pop() || dbPath : '';
-      const title = fileName
-        ? (isDirty ? `${fileName}* - Simple Password Manager` : `${fileName} - Simple Password Manager`)
-        : 'Simple Password Manager';
-      await appWindow.setTitle(title);
+      await appWindow.setTitle(windowTitle);
     };
     updateTitle();
-  }, [dbPath, isDirty]);
+  }, [windowTitle]);
 
   // Handle window close event
   useEffect(() => {
@@ -68,5 +69,5 @@ export function useWindowManagement({ dbPath, isDirty, onCloseRequested }: UseWi
     };
   }, [onCloseRequested]);
 
-  return { isDirtyRef };
+  return { isDirtyRef, windowTitle };
 }

--- a/components/main-app/index.tsx
+++ b/components/main-app/index.tsx
@@ -32,6 +32,7 @@ import { moveGroup } from "@/lib/tauri";
 import { findGroupByUuid, isDescendant } from "@/components/group-tree/utils";
 
 import { CustomTitleBar } from "@/components/CustomTitleBar";
+import { SearchHeader } from "@/components/SearchHeader";
 import { useAutoLock } from "./hooks/useAutoLock";
 import { useWindowManagement } from "./hooks/useWindowManagement";
 import { useSearch } from "./hooks/useSearch";
@@ -85,6 +86,7 @@ export function MainApp({ onClose }: MainAppProps) {
   const [dndActiveData, setDndActiveData] = useState<DragData>(null);
   const [showConflictDialog, setShowConflictDialog] = useState(false);
   const [liveUpdatesEnabled, setLiveUpdatesEnabled] = useState(false);
+  const [isSearchVisible, setIsSearchVisible] = useState(false);
   const { toast } = useToast();
 
   const sensors = useSensors(
@@ -237,7 +239,15 @@ export function MainApp({ onClose }: MainAppProps) {
     setShowConflictDialog(false);
   }, []);
 
-  useKeyboardShortcuts({ onSave: handleSave });
+  useKeyboardShortcuts({ 
+    onSave: handleSave,
+    onToggleSearch: () => setIsSearchVisible(true),
+    onCloseSearch: () => {
+      setIsSearchVisible(false);
+      clearSearch();
+    },
+    isSearchVisible
+  });
   useEntryEvents(handleRefresh);
 
   // Listen for HIBP setting changes from Settings window
@@ -624,15 +634,21 @@ export function MainApp({ onClose }: MainAppProps) {
         <CustomTitleBar 
           title={windowTitle}
           showMenu={true}
-          searchQuery={searchQuery}
-          onSearchChange={handleSearchWithScope}
           isDirty={isDirty}
           onSave={handleSave}
           onLogout={handleClose}
+          onToggleSearch={() => setIsSearchVisible(!isSearchVisible)}
+        />
+        
+        <SearchHeader
+          searchQuery={searchQuery}
+          onSearchChange={handleSearchWithScope}
           searchScope={effectiveSearchScope}
           onSearchScopeChange={handleSearchScopeChange}
           showSearchScopeDropdown={showSearchScopeDropdown}
           isSearchScopeDisabled={isDashboardView}
+          isVisible={isSearchVisible}
+          onToggle={() => setIsSearchVisible(!isSearchVisible)}
         />
 
         <div className="flex flex-1 overflow-hidden">

--- a/components/main-app/index.tsx
+++ b/components/main-app/index.tsx
@@ -32,6 +32,7 @@ import { moveGroup } from "@/lib/tauri";
 import { findGroupByUuid, isDescendant } from "@/components/group-tree/utils";
 
 import { AppHeader } from "./AppHeader";
+import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { useAutoLock } from "./hooks/useAutoLock";
 import { useWindowManagement } from "./hooks/useWindowManagement";
 import { useSearch } from "./hooks/useSearch";
@@ -158,7 +159,7 @@ export function MainApp({ onClose }: MainAppProps) {
   
   useAutoLock(performClose);
   
-  useWindowManagement({
+  const { windowTitle } = useWindowManagement({
     dbPath,
     isDirty,
     onCloseRequested: () => {
@@ -621,6 +622,7 @@ export function MainApp({ onClose }: MainAppProps) {
       onDragEnd={handleDragEnd}
     >
       <div className="flex h-full w-full flex-col">
+        <CustomTitleBar title={windowTitle} />
         <AppHeader
           searchQuery={searchQuery}
           onSearchChange={handleSearchWithScope}

--- a/components/main-app/index.tsx
+++ b/components/main-app/index.tsx
@@ -31,7 +31,6 @@ import { getIconComponent } from "@/components/IconPicker";
 import { moveGroup } from "@/lib/tauri";
 import { findGroupByUuid, isDescendant } from "@/components/group-tree/utils";
 
-import { AppHeader } from "./AppHeader";
 import { CustomTitleBar } from "@/components/CustomTitleBar";
 import { useAutoLock } from "./hooks/useAutoLock";
 import { useWindowManagement } from "./hooks/useWindowManagement";
@@ -622,8 +621,9 @@ export function MainApp({ onClose }: MainAppProps) {
       onDragEnd={handleDragEnd}
     >
       <div className="flex h-full w-full flex-col">
-        <CustomTitleBar title={windowTitle} />
-        <AppHeader
+        <CustomTitleBar 
+          title={windowTitle}
+          showMenu={true}
           searchQuery={searchQuery}
           onSearchChange={handleSearchWithScope}
           isDirty={isDirty}

--- a/lib/window.ts
+++ b/lib/window.ts
@@ -151,7 +151,7 @@ export async function openSettingsWindow() {
       url: `${baseUrl}/settings`,
       title: "Settings",
       width: 600,
-      height: 500,
+      height: 600,
       resizable: false,
       maximizable: false,
       decorations: false,

--- a/lib/window.ts
+++ b/lib/window.ts
@@ -113,6 +113,7 @@ export async function openEntryWindow(entry: EntryData, groupUuid: string) {
       height: 700,
       resizable: false,
       maximizable: false,
+      decorations: false,
       center: true,
     });
 
@@ -153,6 +154,7 @@ export async function openSettingsWindow() {
       height: 500,
       resizable: false,
       maximizable: false,
+      decorations: false,
       center: true,
     });
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "height": 800,
         "resizable": true,
         "fullscreen": false,
+        "decorations": false,
         "minWidth": 800,
         "minHeight": 600
       }
@@ -37,6 +38,11 @@
             "core:window:allow-set-focus",
             "core:window:allow-hide",
             "core:window:allow-show",
+            "core:window:allow-minimize",
+            "core:window:allow-maximize",
+            "core:window:allow-unmaximize",
+            "core:window:allow-is-maximized",
+            "core:window:allow-start-dragging",
             "core:webview:allow-create-webview-window",
             "core:webview:allow-webview-close",
             "core:webview:allow-get-all-webviews",
@@ -61,6 +67,8 @@
             "core:default",
             "core:window:allow-close",
             "core:window:allow-destroy",
+            "core:window:allow-minimize",
+            "core:window:allow-start-dragging",
             "dialog:allow-ask",
             "dialog:allow-confirm",
             "fs:allow-read-file",
@@ -76,6 +84,8 @@
             "core:default",
             "core:window:allow-close",
             "core:window:allow-destroy",
+            "core:window:allow-minimize",
+            "core:window:allow-start-dragging",
             "core:event:allow-emit",
             "dialog:allow-ask"
           ]


### PR DESCRIPTION
This pull request introduces a custom, cross-platform title bar and unified search experience for the password manager app, replacing native window decorations and providing a more consistent UI. It also adds keyboard shortcuts for saving and searching, and makes the window title dynamic based on the current file and unsaved changes. Several screens now use the new title bar for a cohesive look.

**UI/UX Improvements:**

* Added a new `CustomTitleBar` component to replace native window decorations, providing consistent window controls, app icon, file menu, and optional search/settings actions. Integrated into the main app, entry editor, unlock, quick unlock, and settings screens. [[1]](diffhunk://#diff-c276be10e82515e1f6d9326392b045c617b2b361569caa31ef715b5c361adc85R1-R193) [[2]](diffhunk://#diff-89e050ba20da622abb5d2835694775a1dc274f65d86e768938773eaf8f8be94aR207) [[3]](diffhunk://#diff-49f62135082646283028a161894959d5bc9ff8a701a988ec1a3ff29de20d6aa7L160-R163) [[4]](diffhunk://#diff-6e82fda8d46c7047b7f96d83a48eacbb5a9627f6fed65b940a92ad3b49b43f5fL121-R124) [[5]](diffhunk://#diff-e7076a4efd09f85a177f9ab52f8569d6d4511dbfdc650360e85d9b38584e64bdR105)
* Introduced a `SearchHeader` component for a modern, animated search bar with scope selection (global/folder) and keyboard focus management. [[1]](diffhunk://#diff-925721c7f271452f0a39ea09a4f3b69b50836d80b718da0d7c784ddc5bf5e722R1-R110) [[2]](diffhunk://#diff-1d575f26c615a1b08eeddff4410534e1a848bb162cb58f0514b0fdd6ba877586L34-R35)

**Keyboard Shortcuts:**

* Enhanced keyboard shortcut support: Ctrl/Cmd+S to save, Ctrl/Cmd+F to open search, and Escape to close search if visible. [[1]](diffhunk://#diff-1d6420b719139c1156a44f1c2f1f7e46ac59b21f5777d696f6d088b2511de406R7-R34) [[2]](diffhunk://#diff-1d575f26c615a1b08eeddff4410534e1a848bb162cb58f0514b0fdd6ba877586L240-R250)

**Window Management:**

* Updated window title dynamically to reflect the current database file and unsaved changes, and exposed the computed title for use in custom title bars. [[1]](diffhunk://#diff-6d1a08c03383384ec64cedab2af743488fea5b9b5fbb2c42a1b6f1278c8500c3L21-R34) [[2]](diffhunk://#diff-6d1a08c03383384ec64cedab2af743488fea5b9b5fbb2c42a1b6f1278c8500c3L71-R72) [[3]](diffhunk://#diff-1d575f26c615a1b08eeddff4410534e1a848bb162cb58f0514b0fdd6ba877586L161-R163)

**Screen Integration:**

* Updated `UnlockScreen`, `QuickUnlockScreen`, `Settings`, and `EntryEditor` to use the new `CustomTitleBar`, replacing their old headers and removing redundant footers. [[1]](diffhunk://#diff-49f62135082646283028a161894959d5bc9ff8a701a988ec1a3ff29de20d6aa7R13) [[2]](diffhunk://#diff-49f62135082646283028a161894959d5bc9ff8a701a988ec1a3ff29de20d6aa7R243) [[3]](diffhunk://#diff-6e82fda8d46c7047b7f96d83a48eacbb5a9627f6fed65b940a92ad3b49b43f5fR11) [[4]](diffhunk://#diff-6e82fda8d46c7047b7f96d83a48eacbb5a9627f6fed65b940a92ad3b49b43f5fR173) [[5]](diffhunk://#diff-e7076a4efd09f85a177f9ab52f8569d6d4511dbfdc650360e85d9b38584e64bdR23) [[6]](diffhunk://#diff-e7076a4efd09f85a177f9ab52f8569d6d4511dbfdc650360e85d9b38584e64bdL329-L335) [[7]](diffhunk://#diff-89e050ba20da622abb5d2835694775a1dc274f65d86e768938773eaf8f8be94aR12)

These changes modernize the app's look and feel, improve usability, and set the foundation for further UI enhancements.